### PR TITLE
Show cursor before exiting

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,6 +2,7 @@
 
 use std::io::{self, Write};
 use std::ops;
+use cursor;
 
 /// A terminal restorer, which keeps the previous state of the terminal, and restores it, when
 /// dropped.
@@ -30,6 +31,11 @@ pub struct RawTerminal<W: Write> {
 #[cfg(not(target_os = "redox"))]
 impl<W: Write> Drop for RawTerminal<W> {
     fn drop(&mut self) {
+        // In the event that the cursor is hidden, this will show it before
+        // exiting, preventing the parent process (most likely a shell) from
+        // suppressing the cursor.
+        write!(self, "{}", cursor::Show);
+
         use termios::set_terminal_attr;
         set_terminal_attr(&mut self.prev_ios as *mut _);
     }


### PR DESCRIPTION
If the cursor is hidden when the terminal is dropped, the controlling process (most likely a shell) won't display a cursor. By sending a show cursor escape code, we guarantee that the cursor is restored prior to shutdown.
